### PR TITLE
Improvements (thickness, forceRemoveLines, bug fixed)

### DIFF
--- a/DrawLine3D.gd
+++ b/DrawLine3D.gd
@@ -64,8 +64,8 @@ func ForceRemoveLines():
 func DrawLine(Start, End, LineColor, Time = 0.0, Thickness = 1):
 	Lines.append(Line.new(Start, End, LineColor, Time, Thickness))
 
-func DrawRay(Start, Ray, LineColor, Time = 0.0):
-	Lines.append(Line.new(Start, Start + Ray, LineColor, Time, self.Thickness))
+func DrawRay(Start, Ray, LineColor, Time = 0.0, Thickness = 1):
+	Lines.append(Line.new(Start, Start + Ray, LineColor, Time, Thickness))
 
 func DrawCube(Center, HalfExtents, LineColor, Time = 0.0):
 	#Start at the 'top left'

--- a/DrawLine3D.gd
+++ b/DrawLine3D.gd
@@ -1,16 +1,24 @@
 extends Node2D
 
+
 class Line:
 	var Start
 	var End
 	var LineColor
 	var Time
+	var Thickness
 	
-	func _init(Start, End, LineColor, Time):
+	
+	func _init(Start, End, LineColor, Time, Thickness):
+		if not int(typeof(Time)) == 2 and not int(typeof(Time)) == 3:
+			Time = 0.0
+		
+		
 		self.Start = Start
 		self.End = End
 		self.LineColor = LineColor
 		self.Time = Time
+		self.Thickness = Thickness
 
 var Lines = []
 var RemovedLine = false
@@ -36,7 +44,7 @@ func _draw():
 			Cam.is_position_behind(Lines[i].End)):
 			continue
 		
-		draw_line(ScreenPointStart, ScreenPointEnd, Lines[i].LineColor)
+		draw_line(ScreenPointStart, ScreenPointEnd, Lines[i].LineColor, Lines[i].Thickness)
 	
 	#Remove lines that have timed out
 	var i = Lines.size() - 1
@@ -45,12 +53,19 @@ func _draw():
 			Lines.remove(i)
 			RemovedLine = true
 		i -= 1
+		
+func ForceRemoveLines():
+	var i = Lines.size() - 1
+	while (i >= 0):
+		Lines.remove(i)
+		RemovedLine = true
+		i -= 1
 
-func DrawLine(Start, End, LineColor, Time = 0.0):
-	Lines.append(Line.new(Start, End, LineColor, Time))
+func DrawLine(Start, End, LineColor, Time = 0.0, Thickness = 1):
+	Lines.append(Line.new(Start, End, LineColor, Time, Thickness))
 
 func DrawRay(Start, Ray, LineColor, Time = 0.0):
-	Lines.append(Line.new(Start, Start + Ray, LineColor, Time))
+	Lines.append(Line.new(Start, Start + Ray, LineColor, Time, self.Thickness))
 
 func DrawCube(Center, HalfExtents, LineColor, Time = 0.0):
 	#Start at the 'top left'


### PR DESCRIPTION
Added argument: Thickness (the Godot draw line command has the argument thickness but it wasn't used, with this it is, if you leave it blank it will be set to the default: 1)
Added new command: ForceRemoveLines() which will remove all lines currently placed (even when setting the time to 0 if the target is moving sometimes you will still see multiple lines, use this command before placing a new line to always make sure you only have 1 line)
Added ability to set time as false or true without an error which will result in time being set to 0
Prevented an error resulting when setting time to something else like a string (if you do, it will be set to 0)

-------------------
These improvements are only made to the DrawLine command, using the DrawRay command and the DrawCube command still works just fine but these new improvements haven't been implemented there yet, I might do this myself later but if you want to do it just allow these arguments to be parsed over to the draw command and you should be all good!